### PR TITLE
Add basic web server for image gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ A modern, lightweight system monitoring application for Windows, designed to dis
    dotnet run
    ```
 
-The application starts a web server at `http://localhost:8080` where you can upload images and manage the slideshow gallery.
+The application starts a web server at `http://localhost:8080`.
+Visit `/gallery` in your browser to upload or delete images through a responsive interface powered by Tailwind CSS. Any changes made here are immediately reflected in the running slideshow.

--- a/README.md
+++ b/README.md
@@ -38,5 +38,4 @@ A modern, lightweight system monitoring application for Windows, designed to dis
    dotnet run
    ```
 
-The application starts a web server at `http://localhost:8080`.
-Visit `/gallery` in your browser to upload or delete images through a responsive interface powered by Tailwind CSS. Any changes made here are immediately reflected in the running slideshow.
+The application starts a web server at `http://localhost:8080` where you can upload images and manage the slideshow gallery.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,21 @@ A modern, lightweight system monitoring application for Windows, designed to dis
 - **Administrative Privileges**: Required for GPU monitoring via LibreHardwareMonitor.
 - **Monitor**: A 960x640 resolution monitor is recommended for optimal display.
 
+
 ## Installation
 
 1. **Clone the Repository**:
    ```bash
    git clone git@github.com:thanatath/aidaAlternative.git
    cd aidaAlternative
+   ```
+2. **Build**:
+   ```bash
+   dotnet build
+   ```
+3. **Run**:
+   ```bash
+   dotnet run
+   ```
+
+The application starts a web server at `http://localhost:8080` where you can upload images and manage the slideshow gallery.

--- a/Services/SlideshowManager.cs
+++ b/Services/SlideshowManager.cs
@@ -63,16 +63,6 @@ namespace aidaAlternative.Services
             }
         }
 
-        public void ReloadImages()
-        {
-            images.ForEach(img => img.Dispose());
-            images = LoadImages();
-            if (currentIndex >= images.Count)
-            {
-                currentIndex = 0;
-            }
-        }
-
         public void Dispose()
         {
             images?.ForEach(img => img.Dispose());

--- a/Services/SlideshowManager.cs
+++ b/Services/SlideshowManager.cs
@@ -63,6 +63,16 @@ namespace aidaAlternative.Services
             }
         }
 
+        public void ReloadImages()
+        {
+            images.ForEach(img => img.Dispose());
+            images = LoadImages();
+            if (currentIndex >= images.Count)
+            {
+                currentIndex = 0;
+            }
+        }
+
         public void Dispose()
         {
             images?.ForEach(img => img.Dispose());

--- a/StatesForm.cs
+++ b/StatesForm.cs
@@ -42,7 +42,7 @@ namespace aidaAlternative
             performanceMonitor = new PerformanceMonitor();
             slideshowManager = new SlideshowManager();
             systemTrayManager = new SystemTrayManager(ShowForm, HideForm, ExitApplication);
-            webServer = new SimpleWebServer();
+            webServer = new SimpleWebServer(8080, slideshowManager.ReloadImages);
             webServer.Start();
             statItems = new List<StatItem>();
             InitializeStatItems();

--- a/StatesForm.cs
+++ b/StatesForm.cs
@@ -42,7 +42,7 @@ namespace aidaAlternative
             performanceMonitor = new PerformanceMonitor();
             slideshowManager = new SlideshowManager();
             systemTrayManager = new SystemTrayManager(ShowForm, HideForm, ExitApplication);
-            webServer = new SimpleWebServer(8080, slideshowManager.ReloadImages);
+            webServer = new SimpleWebServer();
             webServer.Start();
             statItems = new List<StatItem>();
             InitializeStatItems();

--- a/StatesForm.cs
+++ b/StatesForm.cs
@@ -2,6 +2,7 @@
 using aidaAlternative.Services;
 using aidaAlternative.SystemTray;
 using aidaAlternative.UI;
+using aidaAlternative.WebServer;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -15,6 +16,7 @@ namespace aidaAlternative
         private readonly PerformanceMonitor performanceMonitor;
         private readonly SlideshowManager slideshowManager;
         private readonly SystemTrayManager systemTrayManager;
+        private readonly SimpleWebServer webServer;
         private readonly List<StatItem> statItems;
         private readonly Timer updateTimer;
         private readonly Timer fadeTimer;
@@ -40,6 +42,8 @@ namespace aidaAlternative
             performanceMonitor = new PerformanceMonitor();
             slideshowManager = new SlideshowManager();
             systemTrayManager = new SystemTrayManager(ShowForm, HideForm, ExitApplication);
+            webServer = new SimpleWebServer();
+            webServer.Start();
             statItems = new List<StatItem>();
             InitializeStatItems();
 
@@ -173,6 +177,7 @@ namespace aidaAlternative
                 performanceMonitor?.Dispose();
                 slideshowManager?.Dispose();
                 systemTrayManager?.Dispose();
+                webServer?.Dispose();
             }
             base.Dispose(disposing);
         }

--- a/WebServer/SimpleWebServer.cs
+++ b/WebServer/SimpleWebServer.cs
@@ -14,12 +14,12 @@ namespace aidaAlternative.WebServer
         private Thread? serverThread;
         private bool isRunning;
 
-        public SimpleWebServer(int port = 8080)
+        public SimpleWebServer(int port = 5001)
         {
             imagesDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "images");
             Directory.CreateDirectory(imagesDir);
             listener = new HttpListener();
-            listener.Prefixes.Add($"http://*:{port}/");
+            listener.Prefixes.Add($"http://127.0.0.1:{port}/");
         }
 
         public void Start()

--- a/WebServer/SimpleWebServer.cs
+++ b/WebServer/SimpleWebServer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net;
+using aidaAlternative.Services;
 using System.Text;
 using System.Threading;
 using System.Net;
@@ -11,15 +12,17 @@ namespace aidaAlternative.WebServer
     {
         private readonly HttpListener listener;
         private readonly string imagesDir;
+        private readonly Action? galleryChanged;
         private Thread? serverThread;
         private bool isRunning;
 
-        public SimpleWebServer(int port = 8080)
+        public SimpleWebServer(int port = 8080, Action? onGalleryChanged = null)
         {
             imagesDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "images");
             Directory.CreateDirectory(imagesDir);
             listener = new HttpListener();
             listener.Prefixes.Add($"http://*:{port}/");
+            galleryChanged = onGalleryChanged;
         }
 
         public void Start()
@@ -91,19 +94,27 @@ namespace aidaAlternative.WebServer
         private void ServeGallery(HttpListenerResponse resp)
         {
             var sb = new StringBuilder();
-            sb.Append("<html><body>");
-            sb.Append("<h1>Gallery</h1>");
-            sb.Append("<form method='post' enctype='multipart/form-data' action='/upload'>");
-            sb.Append("<input type='file' name='file'/><input type='submit' value='Upload'/>");
-            sb.Append("</form><hr>");
+            sb.Append("<html><head><title>Slideshow Gallery</title>");
+            sb.Append("<script src='https://cdn.tailwindcss.com'></script></head>");
+            sb.Append("<body class='bg-gray-100 p-4'>");
+            sb.Append("<div class='container mx-auto'>");
+            sb.Append("<h1 class='text-2xl font-bold mb-4 text-center'>Slideshow Gallery</h1>");
+            sb.Append("<form class='mb-6 flex flex-col sm:flex-row items-center justify-center gap-2' method='post' enctype='multipart/form-data' action='/upload'>");
+            sb.Append("<input type='file' name='file' class='file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:bg-blue-600 file:text-white file:cursor-pointer'/>");
+            sb.Append("<button type='submit' class='bg-green-500 text-white px-4 py-2 rounded'>Upload</button>");
+            sb.Append("</form>");
+            sb.Append("<div class='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4'>");
             foreach (var file in Directory.GetFiles(imagesDir))
             {
                 var name = Path.GetFileName(file);
                 var encoded = WebUtility.UrlEncode(name);
-                sb.Append($"<div><img src='/images/{encoded}' style='max-width:200px'/><br>");
-                sb.Append($"<form method='post' action='/delete?name={encoded}'><input type='submit' value='Delete'/></form></div><br>");
+                sb.Append("<div class='bg-white rounded shadow p-4'>");
+                sb.Append($"<img class='w-full h-auto object-contain mb-2' src='/images/{encoded}' />");
+                sb.Append($"<form method='post' action='/delete?name={encoded}'>");
+                sb.Append("<button class='bg-red-500 text-white px-2 py-1 rounded w-full'>Delete</button>");
+                sb.Append("</form></div>");
             }
-            sb.Append("</body></html>");
+            sb.Append("</div></div></body></html>");
             var bytes = Encoding.UTF8.GetBytes(sb.ToString());
             resp.ContentType = "text/html";
             resp.ContentLength64 = bytes.Length;
@@ -166,6 +177,7 @@ namespace aidaAlternative.WebServer
             var end = content.IndexOf(boundary, start) - 4;
             var fileData = data.AsSpan(start, end - start).ToArray();
             File.WriteAllBytes(Path.Combine(imagesDir, filename), fileData);
+            galleryChanged?.Invoke();
             resp.Redirect("/gallery");
             resp.Close();
         }
@@ -203,6 +215,7 @@ namespace aidaAlternative.WebServer
                 if (File.Exists(path))
                 {
                     File.Delete(path);
+                    galleryChanged?.Invoke();
                 }
             }
             resp.Redirect("/gallery");

--- a/WebServer/SimpleWebServer.cs
+++ b/WebServer/SimpleWebServer.cs
@@ -1,0 +1,225 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Net;
+
+namespace aidaAlternative.WebServer
+{
+    public class SimpleWebServer : IDisposable
+    {
+        private readonly HttpListener listener;
+        private readonly string imagesDir;
+        private Thread? serverThread;
+        private bool isRunning;
+
+        public SimpleWebServer(int port = 8080)
+        {
+            imagesDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "images");
+            Directory.CreateDirectory(imagesDir);
+            listener = new HttpListener();
+            listener.Prefixes.Add($"http://*:{port}/");
+        }
+
+        public void Start()
+        {
+            if (isRunning) return;
+            isRunning = true;
+            listener.Start();
+            serverThread = new Thread(Listen) { IsBackground = true };
+            serverThread.Start();
+        }
+
+        private void Listen()
+        {
+            while (isRunning)
+            {
+                try
+                {
+                    var context = listener.GetContext();
+                    ThreadPool.QueueUserWorkItem(_ => HandleRequest(context));
+                }
+                catch (HttpListenerException)
+                {
+                    // Listener was stopped
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"WebServer error: {ex.Message}");
+                }
+            }
+        }
+
+        private void HandleRequest(HttpListenerContext context)
+        {
+            var req = context.Request;
+            var resp = context.Response;
+            try
+            {
+                if (req.HttpMethod == "GET" && (req.Url?.AbsolutePath == "/" || req.Url?.AbsolutePath == "/gallery"))
+                {
+                    ServeGallery(resp);
+                }
+                else if (req.HttpMethod == "GET" && req.Url?.AbsolutePath.StartsWith("/images/") == true)
+                {
+                    ServeImage(resp, req.Url.AbsolutePath.Substring("/images/".Length));
+                }
+                else if (req.HttpMethod == "POST" && req.Url?.AbsolutePath == "/upload")
+                {
+                    HandleUpload(req, resp);
+                }
+                else if (req.HttpMethod == "POST" && req.Url?.AbsolutePath == "/delete")
+                {
+                    var name = req.QueryString["name"];
+                    HandleDelete(resp, name);
+                }
+                else
+                {
+                    resp.StatusCode = 404;
+                    resp.Close();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"WebServer request error: {ex.Message}");
+                try { resp.StatusCode = 500; resp.Close(); } catch { }
+            }
+        }
+
+        private void ServeGallery(HttpListenerResponse resp)
+        {
+            var sb = new StringBuilder();
+            sb.Append("<html><body>");
+            sb.Append("<h1>Gallery</h1>");
+            sb.Append("<form method='post' enctype='multipart/form-data' action='/upload'>");
+            sb.Append("<input type='file' name='file'/><input type='submit' value='Upload'/>");
+            sb.Append("</form><hr>");
+            foreach (var file in Directory.GetFiles(imagesDir))
+            {
+                var name = Path.GetFileName(file);
+                var encoded = WebUtility.UrlEncode(name);
+                sb.Append($"<div><img src='/images/{encoded}' style='max-width:200px'/><br>");
+                sb.Append($"<form method='post' action='/delete?name={encoded}'><input type='submit' value='Delete'/></form></div><br>");
+            }
+            sb.Append("</body></html>");
+            var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+            resp.ContentType = "text/html";
+            resp.ContentLength64 = bytes.Length;
+            resp.OutputStream.Write(bytes, 0, bytes.Length);
+            resp.Close();
+        }
+
+        private void ServeImage(HttpListenerResponse resp, string filename)
+        {
+            var path = Path.Combine(imagesDir, filename);
+            if (File.Exists(path))
+            {
+                try
+                {
+                    var bytes = File.ReadAllBytes(path);
+                    resp.ContentType = "image/png";
+                    resp.ContentLength64 = bytes.Length;
+                    resp.OutputStream.Write(bytes, 0, bytes.Length);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error serving image: {ex.Message}");
+                    resp.StatusCode = 500;
+                }
+            }
+            else
+            {
+                resp.StatusCode = 404;
+            }
+            resp.Close();
+        }
+
+        private void HandleUpload(HttpListenerRequest req, HttpListenerResponse resp)
+        {
+            if (!req.HasEntityBody)
+            {
+                resp.StatusCode = 400;
+                resp.Close();
+                return;
+            }
+            var boundary = GetBoundary(req.ContentType);
+            if (boundary == null)
+            {
+                resp.StatusCode = 400;
+                resp.Close();
+                return;
+            }
+            using var ms = new MemoryStream();
+            req.InputStream.CopyTo(ms);
+            var data = ms.ToArray();
+            var content = Encoding.UTF8.GetString(data);
+            var filename = GetFileName(content);
+            if (filename == null)
+            {
+                resp.StatusCode = 400;
+                resp.Close();
+                return;
+            }
+            var start = content.IndexOf("\r\n\r\n") + 4;
+            var end = content.IndexOf(boundary, start) - 4;
+            var fileData = data.AsSpan(start, end - start).ToArray();
+            File.WriteAllBytes(Path.Combine(imagesDir, filename), fileData);
+            resp.Redirect("/gallery");
+            resp.Close();
+        }
+
+        private string? GetBoundary(string contentType)
+        {
+            var idx = contentType?.IndexOf("boundary=") ?? -1;
+            if (idx >= 0)
+            {
+                return "--" + contentType[(idx + 9)..];
+            }
+            return null;
+        }
+
+        private string? GetFileName(string content)
+        {
+            var idx = content.IndexOf("filename=\"");
+            if (idx >= 0)
+            {
+                idx += 10;
+                var end = content.IndexOf('"', idx);
+                if (end > idx)
+                {
+                    return Path.GetFileName(content[idx..end]);
+                }
+            }
+            return null;
+        }
+
+        private void HandleDelete(HttpListenerResponse resp, string? name)
+        {
+            if (!string.IsNullOrEmpty(name))
+            {
+                var path = Path.Combine(imagesDir, name);
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            resp.Redirect("/gallery");
+            resp.Close();
+        }
+
+        public void Stop()
+        {
+            if (!isRunning) return;
+            isRunning = false;
+            listener.Stop();
+        }
+
+        public void Dispose()
+        {
+            Stop();
+            listener.Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `SimpleWebServer` to host image upload/gallery
- start web server from `StatsForm` and dispose on exit
- document running the server in `README`

## Testing
- `dotnet build aidaAlternative.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684415196370832a8f9fbb642bdf547f